### PR TITLE
syng ref feature (enumerating syncmers that occur once and only once in the reference)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ CFLAGS = -O3
 
 ALL = syng ONEview syngmap syngref
 
-#DESTDIR = ~/bin
-DESTDIR = /Users/am86/Documents/DurbinRotation/Code/syng_environment/
+DESTDIR = ~/bin
 
 all: $(ALL)
 

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@
 CFLAGS = -O3
 #CFLAGS = -g	# for debugging
 
-ALL = syng ONEview syngmap
+ALL = syng ONEview syngmap syngref
 
-DESTDIR = ~/bin
+#DESTDIR = ~/bin
+DESTDIR = /Users/am86/Documents/DurbinRotation/Code/syng_environment/
 
 all: $(ALL)
 
@@ -57,6 +58,9 @@ syngprune: syngprune.c seqio.o ONElib.o $(UTILS_OBJS)
 
 syngbwt: syngbwt.c syng.h seqio.o seqhash.o kmerhash.o ONElib.o $(UTILS_OBJS)
 	$(CC) $(CFLAGS) -o $@ $^ $(SEQIO_LIBS) syngbwt.o
+
+syngref: syngref.c seqio.o seqhash.o kmerhash.o ONElib.o $(UTILS_OBJS)
+	$(CC) $(CFLAGS) -o $@ $^ $(SEQIO_LIBS)
 
 ONEview: ONEview.c ONElib.o
 	$(CC) $(CFLAGS) -o $@ $^ -lz

--- a/syng.h
+++ b/syng.h
@@ -86,6 +86,8 @@ static char *syngSchemaText =
   "O N 1 6 STRING            name of sequence, e.g. chr1\n"
   "O I 1 8 INT_LIST          list of indexes into name table for each sync: 0 if missing, -ve if RC\n"
   "D P 1 8 INT_LIST          positions in sequence\n"
+  "D O 1 8 INT_LIST          number of occurences in the reference\n"
+
   ;
 
 /****************** end of file ********************/

--- a/syngref.c
+++ b/syngref.c
@@ -78,7 +78,7 @@ int main (int argc, char *argv[])
     OneFile *ofK = oneFileOpenRead (argv[0], schema, "khash", 1) ;
     if (!ofK) die ("failed to open .1khash file %s", argv[0]) ;
 
-    SeqIO   *sio = seqIOopenRead (argv[1], dna2indexConv, false) ;
+    SeqIO   *sio = seqIOopenRead (argv[1], dna2index4Conv, false) ;
     if (!sio) die ("failed to open sequence file %s", argv[1]) ;
     
     // set up output file here 

--- a/syngref.c
+++ b/syngref.c
@@ -1,0 +1,105 @@
+/*  File: syngref.c
+ *  Author: Anant Maheshwari (am3320@cam.ac.uk)
+ *  Copyright (C) Richard Durbin, Cambridge University, 2024
+ *-------------------------------------------------------------------
+ * Description: determine locations of syncmers in a <syng>.1khash within a reference (.fa) genome
+ * Exported functions:
+ * HISTORY:
+ * Last edited: Jan  7 11:16 2025 (am3320)
+ * Created: Mon Jan  6 14:51  2024 (am3320)
+ *-------------------------------------------------------------------
+ */
+
+#include "syng.h"
+#include "seqhash.h"
+#include "seqio.h"
+#include "ONElib.h"
+
+
+/******************* package to handle syncmer parameters *************/
+
+typedef struct {
+  int w, k, seed ;
+} Params ;
+
+static int PARAMS_K_DEFAULT = 8 ;
+static int PARAMS_W_DEFAULT = 55 ;
+static int PARAMS_SEED_DEFAULT = 7 ;
+
+static void readParams (OneFile *of, Params *p)
+{ while (oneReadLine (of) && of->lineType != 'h') ;
+  if (of->lineType != 'h') die ("sync file %s has no 'h' parameters record", oneFileName(of)) ;
+  p->k = oneInt(of,0) ; p->w = oneInt(of,1) ; p->seed = oneInt(of,2) ;
+  fprintf (stdout, "read syncmer parameters k %d w %d (size %d) seed %d\n",
+	   p->k, p->w, p->k + p->w, p->seed) ;
+}
+
+static void checkParams (OneFile *of, Params *p)
+{
+  if (oneInt(of,0) != p->k ||
+      oneInt(of,1) != p->w ||
+      oneInt(of,2) != p->seed)
+    die ("hash parameters mismatch: (k,w,s) file (%d,%d,%d) != code (%d,%d,%d)",
+	 oneInt(of,0), oneInt(of,1), oneInt(of,2), p->k, p->w, p->seed) ;
+}
+
+
+/**************** main program ********************/
+
+static char *usage = 
+  "Usage: syngref [options]* <.1khash file> <reference .fa file>\n"
+  "possible options are:\n"
+  "  -T <threads>           : [8] number of threads\n"
+  "  -o <outfile prefix>    : default is syngref, file type is .1ref\n";
+
+int main (int argc, char *argv[])
+{
+    fprintf(stdout, "Hello, world!\n");
+
+    storeCommandLine (argc--, argv++) ;
+    timeUpdate (0) ;
+
+    if (!argc) { fprintf (stderr, "%s", usage) ; exit (0) ; }
+      char *outPrefix = "syngref" ;
+
+    if (argc != 2) die ("missing the three required arguments\n%s", usage) ;
+
+    OneSchema *schema = oneSchemaCreateFromText (syngSchemaText) ;
+    if (!schema) die ("problem creating schema - needs debugging/recompilation") ;
+    
+      // open all the files here, so we can die quickly if any file opens fail
+    OneFile *ofK = oneFileOpenRead (argv[0], schema, "khash", 1) ;
+    if (!ofK) die ("failed to open .1khash file %s", argv[0]) ;
+
+    SeqIO   *sio = seqIOopenRead (argv[1], dna2indexConv, false) ;
+    if (!sio) die ("failed to open sequence file %s", argv[1]) ;
+    
+    // set up output file here 
+    // TODO - add output file
+
+    // read the khash  
+    Params     params ;
+    readParams (ofK, &params) ;                    // read the syncmer hash parameters
+    fprintf(stdout, "params: k=%d, w=%d, seed=%d\n", params.k, params.w, params.seed);
+
+    Seqhash *sh = seqhashCreate (params.k, params.w+1, params.seed) ; // need the +1 here, awkwardly
+    KmerHash  *kh = kmerHashReadOneFile (ofK) ;    // read in the kmerhash
+    
+    if (kh->len != params.w + params.k)
+        die ("syncmer len mismatch %d != %d + %d", kh->len, params.w, params.k) ;
+    printf ("read %llu kmers from %s\n", kh->max, oneFileName (ofK)) ;
+    oneFileClose (ofK) ;
+    timeUpdate (stdout) ;
+
+    int i, j ; // general index variables
+
+    seqIOclose (sio) ;
+    kmerHashDestroy (kh) ;
+    oneSchemaDestroy (schema) ;				   
+                    
+    timeUpdate (stderr) ;
+    timeTotal (stderr) ;
+    
+    // clean up memory
+}
+

--- a/syngref.c
+++ b/syngref.c
@@ -2,10 +2,10 @@
  *  Author: Anant Maheshwari (am3320@cam.ac.uk)
  *  Copyright (C) Richard Durbin, Cambridge University, 2024
  *-------------------------------------------------------------------
- * Description: determine locations of syncmers in a <syng>.1khash within a reference (.fa) genome
+ * Description: determine locations of syncmers from a <syng>.1khash within a reference (.fa) genome
  * Exported functions:
  * HISTORY:
- * Last edited: Jan  7 11:16 2025 (am3320)
+ * Last edited: Jan  8 15:29 2025 (am3320)
  * Created: Mon Jan  6 14:51  2024 (am3320)
  *-------------------------------------------------------------------
  */
@@ -43,31 +43,28 @@ static void checkParams (OneFile *of, Params *p)
 	 oneInt(of,0), oneInt(of,1), oneInt(of,2), p->k, p->w, p->seed) ;
 }
 
-
 /**************** main program ********************/
 
 static char *usage = 
   "Usage: syngref [options]* <.1khash file> <reference .fa file>\n"
   "possible options are:\n"
-  "  -T <threads>           : [8] number of threads\n"
   "  -o <outfile prefix>    : default is syngref, file type is .1ref\n";
 
 int main (int argc, char *argv[])
 {
-    fprintf(stdout, "Hello, world!\n");
-
     storeCommandLine (argc--, argv++) ;
     timeUpdate (0) ;
 
     if (!argc) { fprintf (stderr, "%s", usage) ; exit (0) ; }
-      char *outPrefix = "syngref" ;
-
-    if (argc != 2) die ("missing the three required arguments\n%s", usage) ;
+    char *outPrefix = "syngref" ;
+    int nThread = 1 ;
+    printf("arguments: %d %s %s \n", argc, argv[0], argv[1]);
+    if (argc != 2) die ("missing the two required arguments\n%s", usage) ;
 
     OneSchema *schema = oneSchemaCreateFromText (syngSchemaText) ;
     if (!schema) die ("problem creating schema - needs debugging/recompilation") ;
     
-      // open all the files here, so we can die quickly if any file opens fail
+    // open all the files here
     OneFile *ofK = oneFileOpenRead (argv[0], schema, "khash", 1) ;
     if (!ofK) die ("failed to open .1khash file %s", argv[0]) ;
 
@@ -75,7 +72,11 @@ int main (int argc, char *argv[])
     if (!sio) die ("failed to open sequence file %s", argv[1]) ;
     
     // set up output file here 
-    // TODO - add output file
+    OneFile *ofOut = oneFileOpenWriteNew (fnameTag(outPrefix,"1ref"), schema, "ref", true, nThread) ;
+    if (!ofOut) die ("failed to open output file %s", argv[2]) ;
+    oneAddProvenance (ofOut, "syngref", SYNG_VERSION, getCommandLine()) ;
+    oneAddReference (ofOut, argv[0], 1) ;
+    oneAddReference (ofOut, argv[1], 2) ;
 
     // read the khash  
     Params     params ;
@@ -87,19 +88,75 @@ int main (int argc, char *argv[])
     
     if (kh->len != params.w + params.k)
         die ("syncmer len mismatch %d != %d + %d", kh->len, params.w, params.k) ;
+
+    printf("khash length: %d\n", kh->len);
+    printf("khash dimension: %d\n", kh->dim);
+    printf("khash max: %llu\n", kh->max);
+    printf("khash count: %llu\n", kh->count);
     printf ("read %llu kmers from %s\n", kh->max, oneFileName (ofK)) ;
+    
     oneFileClose (ofK) ;
     timeUpdate (stdout) ;
 
-    int i, j ; // general index variables
+    // process the sequences serially
+    I64 totSeq = 0;
+    
+    while (seqIOread(sio)) {
 
-    seqIOclose (sio) ;
-    kmerHashDestroy (kh) ;
-    oneSchemaDestroy (schema) ;				   
-                    
-    timeUpdate (stderr) ;
-    timeTotal (stderr) ;
+        I64 seqLen = sio->seqLen;
+        I64 iSync;
+        I64 seqStart = 0 ;
+        int pos = 0;
+        I64 sync;
+
+        printf("read sequence %s length %" PRIu64 "\n", sqioId(sio), seqLen);
+        char *s = sqioSeq(sio);
+        printf("sequence: %s\n", s);
+        char *id = sqioId(sio);
+        totSeq += seqLen;
+        printf("read sequence %s length %" PRIu64 "\n", sqioId(sio), seqLen);
+        
+        SeqhashIterator *sit = syncmerIterator (sh, s, seqLen) ;
+        while (syncmerNext (sit, 0, &pos, 0)) 
+        {
+            printf("found syncmer at position %" PRIu64 "\n", (uint64_t)pos);
+            sync = 0;
+            if (kmerHashFind (kh, s+pos, &sync)) {
+                printf("found hit: %" PRIu64 "\n", sync);
+                if (sync < 0) sync = -sync ;
+                else sync = 0 ;
+            } else {
+                printf("no hit\n");
+            }
+        }
+        seqhashIteratorDestroy (sit) ;
+    }
+
+    // fill out -- write to .1ref file (using ofOut)
+
+    /*
+    "P 3 ref                   REFERENCE INFORMATION\n"
+    "O N 2 6 STRING 3 INT      name of sequence, e.g. chr1, and its length\n"
+    "O I 1 8 INT_LIST          list of indexes into name table for each sync: 0 if missing, -ve if RC\n"
+    "O P 1 8 INT_LIST          positions in sequence\n"
+
+    for (j = 1 ; j < dictMax (nameDict) ; ++i)
+    { 
+        oneInt(of,1) = arr(chrSize,j,I64) ;
+        char *name = dictName(nameDict,j) ;
+        oneWriteLine (ofOut, 'N', strlen(name), name) ;
+    }
+
+    oneWriteLine (ofOut, 'I', kh->max, index) ;
+    oneWriteLine (ofOut, 'P', kh->max, position) ;
+    */
     
     // clean up memory
+    seqIOclose (sio) ;
+    oneFileClose (ofOut) ;
+    kmerHashDestroy (kh) ;
+    oneSchemaDestroy (schema) ;				   
+    timeUpdate (stderr) ;
+    timeTotal (stderr) ;    
 }
 


### PR DESCRIPTION
Initial implementation of **syngref <.1khash> <reference.fa>** functionality (enumerate number of syncmers that occur in the .1khash (many genomes) and that occur once and only once in the reference genome. TODO: detailed tests for this.

Output is of format:

  "O N 1 6 STRING            name of sequence, e.g. chr1\n"
  "O I 1 8 INT_LIST          list of indexes into name table for each sync: 0 if missing, -ve if RC\n"
  "D P 1 8 INT_LIST          positions in sequence\n"
  "D O 1 8 INT_LIST          number of occurences in the reference\n"
  
  Output: syngref.1ref file
  
  _N_ lines provide chromosome names are in order (1 to n for n chromosomes)
  _I_ line provides chromosome index for each syncmer (-ve if RC)
  _P_ line provides positions in the reference (corresponding to each entry of above line)
  _O_ line provides the number of occurrences of each syncmer in the reference (to track > 1 occurrence cases)
  
