### PR TITLE
Make htslib/BAM support optional in build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ syngmap: syngmap.c syngbwt.o seqio.o seqhash.o kmerhash.o ONElib.o $(UTILS_OBJS)
 	$(CC) $(CFLAGS) -o $@ $^ -lpthread $(SEQIO_LIBS)
 
 syngstat: syngstat.c syngbwt.o ONElib.o $(UTILS_OBJS)
-	$(CC) $(CFLAGS) -o $@ $^ -lz
+	$(CC) $(CFLAGS) -o $@ $^ -lz -lpthread
 
 syngprune: syngprune.c seqio.o ONElib.o $(UTILS_OBJS)
 	$(CC) $(CFLAGS) -o $@ $^ $(SEQIO_LIBS)

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,15 @@ UTILS_OBJS = hash.o dict.o array.o utils.o
 UTILS_HEADERS = utils.h array.h dict.h hash.h
 $(UTILS_OBJS): utils.h $(UTILS_HEADERS)
 
-#SEQIO_OPTS = -DONEIO
-#SEQIO_LIBS = -lm -lz
-
+# Set BAMIO=1 to enable SAM/BAM/CRAM support (requires htslib in ../htslib)
+ifdef BAMIO
 HTS_DIR = $(PWD)/../htslib/.
 SEQIO_OPTS = -DONEIO -DBAMIO -I$(HTS_DIR)/htslib/
-SEQIO_LIBS = -L$(HTS_DIR) -Wl,-rpath $(HTS_DIR) -lhts -lm -lbz2 -llzma -lcurl -lz 
+SEQIO_LIBS = -L$(HTS_DIR) -Wl,-rpath $(HTS_DIR) -lhts -lm -lbz2 -llzma -lcurl -lz
+else
+SEQIO_OPTS = -DONEIO
+SEQIO_LIBS = -lm -lz
+endif 
 
 seqio.o: seqio.c seqio.h ONElib.h $(UTILS_HEADERS)
 	$(CC) $(CFLAGS) $(SEQIO_OPTS) -c $^

--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ are available from the [SEQUENCE_UTILTIES](https://github.com/thegenemyers/ONEco
 ## Building
 ```
   git clone https://github.com/richarddurbin/syng.git
+  cd syng
   make
 ```
-If you want to be able to read SAM/BAM/CRAM files then you need to install [htslib](https://github.com/samtools/htslib) in a parallel directory and use Makefile.bam:
+If you want to be able to read SAM/BAM/CRAM files then you need to install [htslib](https://github.com/samtools/htslib) in a parallel directory and build with `BAMIO=1`:
 
  ```
- cd ..
+  cd ..
   git clone https://github.com/samtools/htslib.git
   cd htslib
   autoreconf -i  # Build the configure script and install files it uses
   ./configure    # Optional but recommended, for choosing extra functionality
   make
-  make install
   cd ../syng
   make clean
-  make -f Makefile.bam
+  make BAMIO=1
 ```
 
 ## Libraries


### PR DESCRIPTION
## Summary
- Add `BAMIO=1` flag to conditionally enable SAM/BAM/CRAM support
- By default, build without htslib dependency (only requires libz)
- Update README to document the new build process and remove reference to non-existent `Makefile.bam`

## Usage
```bash
# Default build (no htslib required)
make

# With BAM/CRAM support (requires htslib in ../htslib)
make BAMIO=1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)